### PR TITLE
adding styling for become a member UL

### DIFF
--- a/assets/scss/_common.scss
+++ b/assets/scss/_common.scss
@@ -97,3 +97,23 @@ textarea.form-control{
 
 }
 // this is an easter egg #3, post in the web team channel if you found me 😁
+
+.member_ul {
+  list-style-type: none;
+  .li_bullet {
+    &::before {
+      content: "";
+      height: 1.5rem;
+      width: 1.5rem;
+      display: inline-block;
+      background-image: url("../images/icons/sparkles.svg");
+      background-size: contain;
+      background-repeat: no-repeat;
+      margin-right: 0.5rem;
+    }
+  }
+
+  li {
+    padding: .25rem;
+  }
+}

--- a/layouts/partials/membership.html
+++ b/layouts/partials/membership.html
@@ -13,10 +13,14 @@
                     {{ range .titleThree }}
                     <h3>{{ .name }}</h3>
                     {{ $icon := .icon}}
+                    <ul class="member_ul d-flex flex-column p-1">
                     {{ range .points }}
-                    <img src="{{ $icon | absURL }}" alt="sparkles-bullet">
-                    <p>{{ . }}</p>
+                        <div class="pb-2 d-flex align-items-center">
+                            <div class="li_bullet align-self-start"></div>
+                            <li>{{ . }}</li>
+                        </div>
                     {{ end }}
+                    </ul>
                     {{ end }}
                 </div>
             </div>


### PR DESCRIPTION
added `ul` image  styling for become a member section:

![image](https://user-images.githubusercontent.com/10230166/165023274-001004e5-ac1c-4774-9573-00d0ee21cdb1.png)

probably doesn't close issue #124, but relates