### PR TITLE
automate list of posts from portfolio by date

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
      - main
+  workflow_dispatch:
  
 
 jobs:

--- a/content/portfolio/axe-hacks-2022.md
+++ b/content/portfolio/axe-hacks-2022.md
@@ -2,7 +2,6 @@
 title: "Axe Hacks '22"
 date: 2022-03-25T15:55:44+06:00
 publishdate: 2022-05-01T21:30:47-04:00
-event_status: event-recap
 image: "images/projects/Axe-Hacks-1.png"
 event_type:
 event_topic:

--- a/content/portfolio/eoy-celebration.md
+++ b/content/portfolio/eoy-celebration.md
@@ -2,7 +2,6 @@
 title: "EOY Celebration"
 date: 2022-05-02T15:55:44+06:00
 publishdate: 2022-05-01T21:30:47-04:00
-event_status: upcoming-event
 image: "images/projects/EOYCelebration.png"
 event_type:
 event_topic:

--- a/content/portfolio/gwc-website-project-2022.md
+++ b/content/portfolio/gwc-website-project-2022.md
@@ -2,7 +2,6 @@
 title: "Web Project '22"
 date: 2022-05-02T20:56:42+06:00
 publishdate: 2022-05-01T21:30:47-04:00
-event_status: upcoming-event
 image: "images/projects/WebTeamIntros.png"
 event_type:
 event_topic:

--- a/content/portfolio/internship-panel.md
+++ b/content/portfolio/internship-panel.md
@@ -2,7 +2,6 @@
 title: "Internship Panel"
 date: 2022-04-29T15:58:10+06:00
 publishdate: 2022-05-01T21:30:47-04:00
-event_status: event-recap
 image: "images/projects/InternshipPanel.png"
 event_type:
 event_topic:

--- a/content/portfolio/venture-team-building.md
+++ b/content/portfolio/venture-team-building.md
@@ -2,7 +2,6 @@
 title: "Venture Event"
 date: 2022-04-22T15:44:46+06:00
 publishdate: 2022-05-01T21:30:47-04:00
-event_status: event-recap
 image: "images/projects/Venture-Flyer.png"
 event_type:
     - 

--- a/content/portfolio/website-launch-party.md
+++ b/content/portfolio/website-launch-party.md
@@ -2,7 +2,6 @@
 title: "Launch Party"
 date: 2022-05-02T15:56:43+06:00
 publishdate: 2022-05-01T21:30:47-04:00
-event_status: upcoming-event
 image: "images/projects/LaunchParty.png"
 event_type:
 event_topic:

--- a/layouts/partials/portfolio.html
+++ b/layouts/partials/portfolio.html
@@ -9,8 +9,9 @@
             <h2 class="black__color--light-purple">{{ .title }}</h2>
           </div>
         </div>
-        {{ range first 3 (where (where site.RegularPages "Section" "portfolio") "Params.event_status" "upcoming-event") }}
-        {{ if eq .Params.event_status "upcoming-event" }}
+        {{ $upcoming_posts := where (where site.RegularPages "Section" "portfolio" ) "Date" ">" now | first 3 }}
+        {{ if gt ($upcoming_posts | len) 0 }}
+        {{ range $upcoming_posts }}
         <div class="col-lg-4 col-md-10">
           <div class="site-project-item">
             <a href="{{ .Permalink }}">
@@ -26,6 +27,10 @@
           </div>
         </div>
         {{ end }}
+        {{ else }}
+        <div class="col-12 text-center">
+          <h4 class="black__color--opposite">Stay tuned for more events!</h4>
+        </div>
         {{ end }}
         <div class="col-12 text-center text-lg-right linked-text__white--blue">
           <a href="calendar" class="site-project-cta">FULL CALENDAR >></a>
@@ -47,7 +52,9 @@
             <h2 class="black__color--light-purple">{{ .title }}</h2>
           </div>
         </div>
-        {{ range first 3 (where (where site.RegularPages "Section" "portfolio") "Params.event_status" "event-recap") }}
+        {{ $recap_posts := where (where site.RegularPages "Section" "portfolio" ) "Date" "<" now | first 3 }}
+        {{ if gt ($recap_posts | len) 0 }}
+        {{ range $recap_posts }}
         <div class="col-lg-4 col-md-10">
           <div class="site-project-item">
             <a href="{{ .Permalink }}">
@@ -61,6 +68,11 @@
               </a>
             </div>
           </div>
+        </div>
+        {{ end }}
+        {{ else }}
+        <div class="col-12 text-center">
+          <h4 class="black__color--opposite">Stay tuned for more events!</h4>
         </div>
         {{ end }}
         <div class="col-12 text-center text-lg-right linked-text__white--blue">


### PR DESCRIPTION
now posts from the portfolio will automatically be placed in "Upcoming Events" or "Event Recap" based on their date vs the current date of the build.

**NOTE:** this will only change posts locations when the website gets rebuilt. So, I've also added a way for you to manually kick off a build from GitHub's actions page: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/