### PR TITLE
Bug/cms uploaded images

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,6 @@
 *.png binary
 *.jpg binary
 *.svg binary
+*.jpeg binary
+*.JPEG binary
+*.JPG binary

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -115,7 +115,7 @@ team:
       website! You can learn more about this project and what each of these
       teammates and roles did [here](../portfolio/gwc-website-project-2022/).
   eboard_members:
-    - image: /images/e-board-headshots.png
+    - image: images/e-board-headshots.png
       name: Elise Frazier
       designation: President
       socials:
@@ -123,25 +123,25 @@ team:
           link: https://www.linkedin.com/in/elise-frazier-89b356180/
         - icon_name: github
           link: https://github.com/ElisefRaz17
-    - image: /images/e-board-headshots-1-.png
+    - image: images/e-board-headshots-1-.png
       name: Jenna Constantino
       designation: VP of Communications
       socials:
         - icon_name: linkedin
           link: https://www.linkedin.com/in/jennaconstantino/
-    - image: /images/e-board-headshots-2-.png
+    - image: images/e-board-headshots-2-.png
       name: Luisa Schenk
       designation: Treasurer
       socials:
         - icon_name: linkedin
           link: https://www.linkedin.com/in/lschenk7/
-    - image: /images/e-board-headshots-3-.png
+    - image: images/e-board-headshots-3-.png
       name: Lulu Aboufoul
       designation: Event Chair 1
       socials:
         - icon_name: linkedin
           link: https://www.linkedin.com/in/lolo-aboufoul/
-    - image: /images/e-board-headshots-4-.png
+    - image: images/e-board-headshots-4-.png
       name: Ashleigh Sico
       designation: Event Chair 2
       socials:

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -4,7 +4,7 @@ backend:
   branch: main # Branch to update (optional; defaults to master)
   # branch: feat/content-management-system # used for development
 media_folder: static/images
-public_folder: /images
+public_folder: images/
 publish_mode: editorial_workflow
 collections:
   - name: list_files


### PR DESCRIPTION
Fixing the CMS bug which was pointing images to non-relative location, causing them to fail when loading.

![image](https://user-images.githubusercontent.com/10230166/188241686-c0fde93a-fa4f-42f0-a3e1-b4a166a6c2f4.png)

broken locally (without changes from this PR):

![image](https://user-images.githubusercontent.com/10230166/188241880-3de8b919-3753-4f02-81f5-bfd183dc171e.png)


Working locally (with changes):

![image](https://user-images.githubusercontent.com/10230166/188241867-9ec3a00e-f9be-4e52-9c7b-3b09e6b56908.png)
