### PR TITLE
Only display partner events via hosts front matter

### DIFF
--- a/content/portfolio/gwc-website-project-2022.md
+++ b/content/portfolio/gwc-website-project-2022.md
@@ -7,6 +7,7 @@ event_type: "Web Dev"
 event_topic: ["Web Team"]
 year: "2022"
 semester: ["Spring"]
+hosts: 
 visibleInCMS: true
 ---
 

--- a/content/portfolio/gwc-website-project-2022.md
+++ b/content/portfolio/gwc-website-project-2022.md
@@ -7,7 +7,7 @@ event_type: "Web Dev"
 event_topic: ["Web Team"]
 year: "2022"
 semester: ["Spring"]
-hosts: 
+co_hosts: 
 visibleInCMS: true
 ---
 

--- a/content/portfolio/venture-team-building.md
+++ b/content/portfolio/venture-team-building.md
@@ -7,7 +7,8 @@ event_type: "Social"
 event_topic: ["Team Building", "Outdoor"]
 year: "2022"
 semester: ["Spring"]
-hosts: ["Venture"]
+host: "GWC_UNCC"
+co_hosts: ["Venture"]
 visibleInCMS: true
 ---
 

--- a/content/portfolio/venture-team-building.md
+++ b/content/portfolio/venture-team-building.md
@@ -7,6 +7,7 @@ event_type: "Social"
 event_topic: ["Team Building", "Outdoor"]
 year: "2022"
 semester: ["Spring"]
+hosts: ["Venture"]
 visibleInCMS: true
 ---
 

--- a/layouts/partials/partnership.html
+++ b/layouts/partials/partnership.html
@@ -39,7 +39,7 @@
                         <div class="container">
                             <div class="row">
                                 <!-- TODO: Limit to events with label of partnership -->
-                                {{ $recap_posts := where (where (where site.RegularPages "Section" "portfolio") "Date" "<" now ) "Params.hosts" "!=" nil | first 3 }}
+                                {{ $recap_posts := where (where (where site.RegularPages "Section" "portfolio") "Date" "<" now ) "Params.co_hosts" "!=" nil | first 3 }}
                                 {{ range $recap_posts }}
                                 <div class="col-lg-4 col-md-10">
                                     <div class="site-project-item">

--- a/layouts/partials/partnership.html
+++ b/layouts/partials/partnership.html
@@ -39,7 +39,7 @@
                         <div class="container">
                             <div class="row">
                                 <!-- TODO: Limit to events with label of partnership -->
-                                {{ $recap_posts := where (where site.RegularPages "Section" "portfolio") "Date" "<" now | first 3 }}
+                                {{ $recap_posts := where (where (where site.RegularPages "Section" "portfolio") "Date" "<" now ) "Params.hosts" "!=" nil | first 3 }}
                                 {{ range $recap_posts }}
                                 <div class="col-lg-4 col-md-10">
                                     <div class="site-project-item">

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -427,6 +427,7 @@ collections:
       - { name: title, label: Title, widget: string }
       - { name: date, label: Event Date, widget: datetime }
       - { name: publishdate, label: Publish Date, widget: datetime }
+      - { name: hosts, label: "Non-GWC Event Hosts (Optional)", widget: list, allow_add: true, required: false }
       - { name: image, label: Event Flyer, widget: image, allow_multiple: false }
       - { name: event_type, label: Event Type, widget: select, options: ["Social", "Professional", "Web Dev", "Hackathon", "Workshop", "Game Night", "Technical"], multiple: false }
       - { name: event_topic, label: Event Topic, widget: list, allow_add: true, min: 1, max: 4 }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -427,7 +427,8 @@ collections:
       - { name: title, label: Title, widget: string }
       - { name: date, label: Event Date, widget: datetime }
       - { name: publishdate, label: Publish Date, widget: datetime }
-      - { name: hosts, label: "Non-GWC Event Hosts (Optional)", widget: list, allow_add: true, required: false }
+      - { name: host, label: "Non-GWC Event Hosts (Default: GWC_UNCC)", widget: string, default: "GWC_UNCC" }
+      - { name: co_hosts, label: "Non-GWC Event Hosts", widget: list, allow_add: true, required: false }
       - { name: image, label: Event Flyer, widget: image, allow_multiple: false }
       - { name: event_type, label: Event Type, widget: select, options: ["Social", "Professional", "Web Dev", "Hackathon", "Workshop", "Game Night", "Technical"], multiple: false }
       - { name: event_topic, label: Event Topic, widget: list, allow_add: true, min: 1, max: 4 }


### PR DESCRIPTION
**NOTE:** This still needs to be tested if it properly puts nothing when not filled in. (didn't want to merge to main without a review)

- adding hosts field to CMS
- adding example empty hosts field
- adding example with correctly defined hosts field
- adapting logic for previous partner events to leverage hosts field

What it currently looks like

![image](https://user-images.githubusercontent.com/10230166/188244464-a23f0eb9-5748-4c68-993f-a932fdda7ea0.png)
