### PR TITLE
adding schedule for re-deploys

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,6 +3,10 @@
 name: Deploy Website
 
 on:
+  schedule:
+    # run the deployment daily to ensure new events get published if
+    #   publish date is in the future
+    - cron: '0 0 * * *'
   push:
     branches:
      - main


### PR DESCRIPTION
if an event is scheduled for the future, it won't show up on the website till hugo re-deploys the website (and it's after the publish_date). So, this modification to the deployment allows those scheduled events to automatically be handled via GH actions instead of manual re-deployment.